### PR TITLE
[FIX] QueryDSL 조인 문제 해결

### DIFF
--- a/src/main/java/umc/product/domain/project/repository/ProjectCustomRepositoryImpl.java
+++ b/src/main/java/umc/product/domain/project/repository/ProjectCustomRepositoryImpl.java
@@ -102,7 +102,7 @@ public class ProjectCustomRepositoryImpl implements ProjectCustomRepository {
                                 .where(memberProjectCount.project.eq(project))
                 ))
                 .from(project)
-                .innerJoin(project.memberProjects, memberProject)
+                .innerJoin(project.memberProjectList, memberProject)
                 .where(memberProject.member.eq(member))
                 .groupBy(project.id, project.title, project.slogan, project.logoUrl, project.prize)
                 .fetch();
@@ -175,7 +175,7 @@ public class ProjectCustomRepositoryImpl implements ProjectCustomRepository {
         return jpaQueryFactory
                 .from(memberProject)
                 .join(memberProject.member, member)
-                .join(memberProject.parts, memberProjectPart)
+                .join(memberProject.memberProjectPartList, memberProjectPart)
                 .where(memberProject.project.id.eq(projectId))
                 .transform(GroupBy.groupBy(member.id)
                         .list(Projections.constructor(


### PR DESCRIPTION
#25 

## 문제 상황
프로젝트 관련 querydsl 쓰는 부분에서 `memberProject.parts`,  `project.memberProjects` 필드가 없다는 에러 뜸

## 문제 원인
1. 컨벤션 맞춘다고 복수 명사 변수명을 ~s -> ~List로 바꿨음
2. Q클래스에 변경된 부분이 반영이 안 됨

## 해결 완료
1. gradle clean build
2. querydsl 조인 부분에서 알맞은 변수명으로 수정