### PR TITLE
:recycle: refactor: 스터디 관련 코드 리팩토링

### DIFF
--- a/src/main/java/umc/product/domain/member/entity/MemberOut.java
+++ b/src/main/java/umc/product/domain/member/entity/MemberOut.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.springframework.data.redis.core.index.Indexed;
 import umc.product.domain.member.entity.enums.OutReason;
+import umc.product.domain.study.entity.WeeklyStudyStatus;
 import umc.product.global.common.base.BaseEntity;
 
 import java.time.LocalDateTime;
@@ -29,5 +30,9 @@ public class MemberOut extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "weekly_study_status_id", nullable = true)
+    private WeeklyStudyStatus weeklyStudyStatus;
 }
 

--- a/src/main/java/umc/product/domain/member/mapper/MemberOutMapper.java
+++ b/src/main/java/umc/product/domain/member/mapper/MemberOutMapper.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import umc.product.domain.member.entity.Member;
 import umc.product.domain.member.entity.MemberOut;
 import umc.product.domain.member.entity.enums.*;
+import umc.product.domain.study.entity.WeeklyStudyStatus;
 
 @Component
 public class MemberOutMapper {
@@ -14,5 +15,14 @@ public class MemberOutMapper {
                 .member(member)
                 .build();
     }
+
+    public MemberOut toMemberOut(Member member, OutReason outReason, WeeklyStudyStatus weeklyStatus) {
+        return MemberOut.builder()
+            .member(member)
+            .outReason(outReason)
+            .weeklyStudyStatus(weeklyStatus) // ★ weeklyStatus를 설정
+            .build();
+    }
+
 }
 

--- a/src/main/java/umc/product/domain/member/repository/jpa/MemberOutJpaRepository.java
+++ b/src/main/java/umc/product/domain/member/repository/jpa/MemberOutJpaRepository.java
@@ -5,9 +5,12 @@ import umc.product.domain.member.entity.MemberOut;
 
 import javax.swing.text.html.Option;
 import java.util.Optional;
+import umc.product.domain.study.entity.WeeklyStudyStatus;
 
 
 public interface MemberOutJpaRepository extends JpaRepository<MemberOut, Long> {
     Optional<MemberOut> findMemberOutById(Long outId);
+
+    Optional<MemberOut> findByWeeklyStudyStatus(WeeklyStudyStatus weeklyStudyStatus);
 }
 

--- a/src/main/java/umc/product/domain/member/service/admin/AdminOutService.java
+++ b/src/main/java/umc/product/domain/member/service/admin/AdminOutService.java
@@ -3,11 +3,15 @@ package umc.product.domain.member.service.admin;
 import umc.product.domain.member.entity.Member;
 import umc.product.domain.member.entity.MemberOut;
 import umc.product.domain.member.entity.enums.OutReason;
+import umc.product.domain.study.entity.WeeklyStudyStatus;
 
 public interface AdminOutService {
 
     MemberOut postMemberOut(Member member,
                             OutReason outReason);
+
+    MemberOut postMemberOutForStudy(Member member, OutReason outReason, WeeklyStudyStatus weeklyStatus);
+
     void modifyMemberOut(Long outId,
                          OutReason outReason,
                          Member member);

--- a/src/main/java/umc/product/domain/member/serviceImpl/admin/AdminOutServiceImpl.java
+++ b/src/main/java/umc/product/domain/member/serviceImpl/admin/AdminOutServiceImpl.java
@@ -10,6 +10,7 @@ import umc.product.domain.member.entity.enums.Status;
 import umc.product.domain.member.mapper.MemberOutMapper;
 import umc.product.domain.member.repository.jpa.MemberOutJpaRepository;
 import umc.product.domain.member.service.admin.AdminOutService;
+import umc.product.domain.study.entity.WeeklyStudyStatus;
 import umc.product.global.common.exception.RestApiException;
 
 import java.util.List;
@@ -24,6 +25,7 @@ public class AdminOutServiceImpl implements AdminOutService {
 
     private final MemberOutMapper memberOutMapper;
 
+
     @Transactional
     @Override
     public MemberOut postMemberOut(
@@ -33,11 +35,27 @@ public class AdminOutServiceImpl implements AdminOutService {
         MemberOut memberOut = memberOutMapper.toMemberOut(member, outReason);
         member.addMemberOut(memberOut);
 
-        //삭제 되지 않은 out 개수 counting
+        return applyOutAndCheckThreshold(member, memberOut);
+    }
+
+    @Transactional
+    @Override
+    public MemberOut postMemberOutForStudy(Member member, OutReason outReason, WeeklyStudyStatus weeklyStatus) {
+        // 매퍼를 통해 weeklyStatus가 포함된 MemberOut을 생성
+        MemberOut memberOut = memberOutMapper.toMemberOut(member, outReason, weeklyStatus);
+        // 공통 로직을 처리하는 private 메서드를 호출
+        return applyOutAndCheckThreshold(member, memberOut);
+    }
+
+    private MemberOut applyOutAndCheckThreshold(Member member, MemberOut memberOut) {
+        member.addMemberOut(memberOut);
         List<MemberOut> memberOutList = member.getMemberOutList().stream()
-                .filter(memberOut1 -> memberOut1.getDeletedAt() == null)
-                .collect(Collectors.toList());
-        if(memberOutList.size() >= 3) member.setStatus(Status.OUT);
+            .filter(memberOut1 -> memberOut1.getDeletedAt() == null)
+            .collect(Collectors.toList());
+
+        if (memberOutList.size() >= 3) {
+            member.setStatus(Status.OUT);
+        }
         return memberOut;
     }
 

--- a/src/main/java/umc/product/domain/study/adviser/admin/AdminStudyAdviser.java
+++ b/src/main/java/umc/product/domain/study/adviser/admin/AdminStudyAdviser.java
@@ -22,6 +22,7 @@ import umc.product.domain.member.entity.Member;
 import umc.product.domain.member.entity.enums.OutReason;
 import umc.product.domain.member.entity.enums.Part;
 import umc.product.domain.member.entity.enums.Role;
+import umc.product.domain.member.repository.jpa.MemberOutJpaRepository;
 import umc.product.domain.member.service.admin.AdminMemberService;
 import umc.product.domain.member.service.admin.AdminOutService;
 import umc.product.domain.member.status.AuthErrorStatus;
@@ -88,6 +89,7 @@ public class AdminStudyAdviser {
     private final RoadmapWeekRepository roadmapWeekRepository;
     private final AdminWeeklyStudyStatusRepository weeklyStudyStatusRepository;
     private final StudyConverter studyConverter;
+    private final MemberOutJpaRepository memberOutJpaRepository;
 
     // 스터디 생성 - 하나의 영속성으로 관리
     // todo - 최적화 필요
@@ -376,19 +378,35 @@ public class AdminStudyAdviser {
             .orElse(WeeklyStudyStatus.builder()
                 .studyMember(studyMember)
                 .week(week)
+                .status(PassStatus.PENDING)
                 .build());
 
-        weeklyStatus.updateStatus(request.getStatus());
-        adminWeeklyStudyStatusRepository.save(weeklyStatus);
+        // 상태 변경 전, 기존 상태를 저장
+        PassStatus oldStatus = weeklyStatus.getStatus();
+        PassStatus newStatus = request.getStatus();
 
-        // 3. 만약 설정된 상태가 'OUT'이라면, 'MemberOut' 경고를 부여
-        if (request.getStatus() == PassStatus.OUT) {
+        // 상태가 실제로 변경되었을 때만 로직 수행
+        if (oldStatus != newStatus) {
+            // 1. WeeklyStudyStatus의 상태를 먼저 업데이트
+            weeklyStatus.updateStatus(newStatus);
+
             Member member = studyMember.getSemesterPart().getMember();
 
-            // '스터디 불이행' 사유로 MemberOut을 생성하는 서비스를 호출
-            // 이 서비스 내부에서 3회 누적 시 최종 OUT 처리 로직이 동작
-            adminOutService.postMemberOut(member, OutReason.STUDY_CHECK_NOT_PERFORM);
+            // 2. [OUT 부여] PENDING/PASS -> OUT으로 변경된 경우
+            if (newStatus == PassStatus.OUT) {
+                // MemberOut 생성 서비스를 호출하고, 어떤 weeklyStatus 때문인지 연결고리를 남깁니다.
+                adminOutService.postMemberOutForStudy(member, OutReason.STUDY_CHECK_NOT_PERFORM, weeklyStatus);
+
+                // 3. [OUT 취소] OUT -> PENDING/PASS로 변경된 경우
+            } else if (oldStatus == PassStatus.OUT) {
+                // 이 weeklyStatus와 연결된 MemberOut을 찾아서 삭제합니다.
+                memberOutJpaRepository.findByWeeklyStudyStatus(weeklyStatus)
+                    .ifPresent(memberOut -> adminOutService.deleteMemberOut(member, memberOut.getId()));
+            }
         }
+
+        weeklyStudyStatusRepository.save(weeklyStatus);
+
         return WeeklyStatusCommonResponse.builder()
             .weeklyStatusId(weeklyStatus.getId())
             .build();

--- a/src/main/java/umc/product/domain/study/converter/member/StudyConverter.java
+++ b/src/main/java/umc/product/domain/study/converter/member/StudyConverter.java
@@ -1,5 +1,8 @@
 package umc.product.domain.study.converter.member;
 
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
 import java.util.Set;
 import org.springframework.stereotype.Component;
 import umc.product.domain.checklist.entity.Checklist;
@@ -24,18 +27,22 @@ public class StudyConverter {
     public StudyResponse toStudyResponse(StudyMember studyMember, List<StudyMemberResponse> studyMemberResponseList, Roadmap roadmap) {
         Study study = studyMember.getStudy();
 
-        List<StudyResponse.WeeklyRoadmapResponse> weeklyRoadmaps = roadmap.getRoadmapWeekList().stream()
-            .map(roadmapWeek -> StudyResponse.WeeklyRoadmapResponse.builder()
-                .week(roadmapWeek.getWeek())
-                .subjects(List.of(roadmapWeek.getSubject()))
+        Map<Integer, List<String>> subjectsPerWeek = roadmap.getRoadmapWeekList().stream()
+            .collect(Collectors.groupingBy(
+                RoadmapWeek::getWeek, // 'week' 필드로 그룹핑
+                Collectors.mapping(RoadmapWeek::getSubject, Collectors.toList()) // 각 그룹의 'subject'를 리스트로 모음
+            ));
+
+        List<StudyResponse.WeeklyRoadmapResponse> weeklyRoadmaps = subjectsPerWeek.entrySet().stream()
+            .map(entry -> StudyResponse.WeeklyRoadmapResponse.builder()
+                .week(entry.getKey())
+                .subjects(entry.getValue())
                 .build())
+            .sorted(Comparator.comparingInt(StudyResponse.WeeklyRoadmapResponse::getWeek)) // 주차 순서대로 정렬
             .collect(Collectors.toList());
 
         // 현재 주차의 주제 목록
-        List<String> currentWeekSubjects = roadmap.getRoadmapWeekList().stream() // <- 수정된 부분
-            .filter(roadmapWeek -> roadmapWeek.getWeek() == study.getCurrentWeek())
-            .map(RoadmapWeek::getSubject)
-            .collect(Collectors.toList());
+        List<String> currentWeekSubjects = subjectsPerWeek.getOrDefault(study.getCurrentWeek(), Collections.emptyList());
 
         return StudyResponse.builder()
             .studyId(study.getId())

--- a/src/main/java/umc/product/domain/study/dto/response/member/StudyResponse.java
+++ b/src/main/java/umc/product/domain/study/dto/response/member/StudyResponse.java
@@ -28,17 +28,11 @@ public class StudyResponse {
     @Schema(description = "스터디 이름", example = "피그말리온")
     private String studyName;
 
-//    @Schema(description = "현재 주차의 로드맵 타이틀 목록", example = "[\"Figma 설치\", \"Figma의 이해\"]")
-//    private List<String> roadmapTitles;
-
     @Schema(description = "현재 주차의 주제 목록", example = "[\"Figma 기본기\", \"Prototyping의 이해\"]")
     private List<String> currentWeekSubjects;
 
     @Schema(description = "스터디 멤버 목록")
     private List<StudyMemberResponse> members;
-
-//    @Schema(description = "주차별 로드맵 정보")
-//    private List<StudyRoadmapResponse> roadmaps;
 
     @Schema(description = "스터디 전체 목차")
     private List<WeeklyRoadmapResponse> weeklyRoadmaps;
@@ -55,18 +49,5 @@ public class StudyResponse {
 
         @Schema(description = "해당 주차의 주제 목록", example = "[\"Figma 기본기\", \"Prototyping의 이해\"]")
         private List<String> subjects;
-    }
-
-    @Schema(description = "주차별 로드맵 정보")
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    public static class StudyRoadmapResponse {
-
-        @Schema(description = "주차", example = "1")
-        private int week;
-
-        @Schema(description = "해당 주차 타이틀 목록", example = "[\"Figma 설치\", \"Figma의 이해\"]")
-        private List<String> titles;
     }
 }

--- a/src/main/java/umc/product/domain/study/entity/WeeklyStudyStatus.java
+++ b/src/main/java/umc/product/domain/study/entity/WeeklyStudyStatus.java
@@ -1,5 +1,6 @@
 package umc.product.domain.study.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,11 +11,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.product.domain.member.entity.MemberOut;
 import umc.product.domain.study.entity.enums.PassStatus;
 
 @Entity
@@ -39,6 +42,9 @@ public class WeeklyStudyStatus {
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private PassStatus status;
+
+  @OneToOne(mappedBy = "weeklyStudyStatus", cascade = CascadeType.ALL)
+  private MemberOut memberOut;
 
   public void updateStatus(PassStatus status) {
     this.status = status;


### PR DESCRIPTION
## 💼 Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [x] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 📚 PR Desciption

> 변경 사항 설명
- 나의 현기수 스터디 정보 조회 api 에서 스터디 주제가 주차별로 한꺼번에 나오지 않고 따로 나오고 있어서 한 주차에 여러 주제가 있을 시에 한꺼번에 반환 가능하도록 수정

- WeeklyStudyStatus 엔티티를 만든 이유: 주차별 상태 기록
  - 어드민 스터디쪽에서 특정 스터디원의 체크리스트 상세를 보고 주차별로 out 부여 버튼이 존재하는데 기존 MemberOut은 멤버 전체에 대한 '경고'만 기록할 뿐, 그 경고가 '몇 주차'의 활동 때문인지는 알 수 없었음.(어떤 스터디원이, 몇 주차에, 어떤 상태(통과/아웃)인지 알 수 없음) 이 문제를 해결하기 위해 WeeklyStudyStatus라는 새로운 엔티티 생성
  
- WeeklyStudyStatus와 MemberOut 1:1 관계를 맺은 이유 
  - 주차별로 out 부여 시 취소도 가능할텐데 OUT 상태를 취소했을 때 수많은 OUT 중 정확히 어떤 것을 지워야 하는지 알 수 없음. 만약 한 멤버가 3주차, 5주차에 스터디 불참으로 MemberOut 경고를 2번 받았다면, 두 경고 모두 사유는 '스터디 불이행'으로 같음. 이때 3주차의 OUT을 취소하려면, 두 경고 중 정확히 3주차 활동으로 인해 발생한 경고를 찾아내야만 함. 따라서 1대 1 연결을 통해 특정 경고를 정확하게 찾아 취소할 수 있게 됨.

- postMemberOut 메서드를 나눈 이유
  - MemberOut은 두 가지 종류의 상황에서 발생 가능 함 
    1. 스터디 불이행: 이 경우에는 원인이 된 WeeklyStudyStatus가 명확히 존재
    2. 다른 사유: 이 경우에는 WeeklyStudyStatus와 아무런 관련이 없음
    따라서 postMemberOut(member, reason): 기존처럼 weeklyStatus 없이 경고를 부여하는 범용 메서드, postMemberOut(member, reason, weeklyStatus): 스터디 불이행 시, 원인이 된 weeklyStatus와 함께 경고를 부여하는 전용 메서드로 나누어서 처리


## 🛰️ 관련 이슈

- close #127 
