### PR TITLE
:bug: fix: 주차별 워크북 조회 API 수정

### DIFF
--- a/src/main/java/umc/product/domain/study/repository/member/StudyCustomRepository.java
+++ b/src/main/java/umc/product/domain/study/repository/member/StudyCustomRepository.java
@@ -18,5 +18,6 @@ public interface StudyCustomRepository {
     List<StudyWeekChecklistResponse.ChecklistResponse> getChecklistResponses(Long studyMemberId, RoadmapSemester roadmapSemester, int week);
     boolean getPostStatus(StudyMember studyMember, int week);
     List<StudyInfoResponse> getStudyInfoList(Member loginMember);
+    StudyMemberResponse getSingleStudyMember(Long studyMemberId, int targetWeek);
 
 }

--- a/src/main/java/umc/product/domain/study/repository/member/StudyCustomRepositoryImpl.java
+++ b/src/main/java/umc/product/domain/study/repository/member/StudyCustomRepositoryImpl.java
@@ -1,5 +1,7 @@
 package umc.product.domain.study.repository.member;
 
+import static umc.product.domain.university.entity.QUniversity.university;
+
 import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -257,6 +259,27 @@ public class StudyCustomRepositoryImpl implements StudyCustomRepository {
                                 GroupBy.list(participant.nickName)
                         ))
                 );
+    }
+
+    @Override
+    public StudyMemberResponse getSingleStudyMember(Long studyMemberId, int targetWeek) {
+        return jpaQueryFactory
+            .select(new QStudyMemberResponse(
+                member.id,
+                member.university.name,
+                member.nickName,
+                studyAttendance.checkStatus.stringValue()
+            ))
+            .from(studyMember)
+            .join(studyMember.semesterPart, semesterPart)
+            .join(semesterPart.member, member)
+            .join(member.university, university)
+            // 출석 정보를 위해 LEFT JOIN을 사용
+            .leftJoin(studyAttendance)
+            .on(studyAttendance.studyMember.id.eq(studyMemberId)
+                .and(studyAttendance.week.eq(targetWeek)))
+            .where(studyMember.id.eq(studyMemberId))
+            .fetchOne();
     }
 
 }

--- a/src/main/java/umc/product/domain/study/service/member/StudyQueryServiceImpl.java
+++ b/src/main/java/umc/product/domain/study/service/member/StudyQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package umc.product.domain.study.service.member;
 
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -65,11 +66,14 @@ public class StudyQueryServiceImpl implements StudyQueryService {
             .orElseThrow(() -> new RestApiException(RoadmapErrorStatus.ROADMAP_SEMESTER_NOT_FOUND));
 
         // N + 1 문제를 해결하기 위해 querydsl을 사용하여 StudyMemberResponse 조회
-        List<StudyMemberResponse> studyMemberResponseList = studyRepository.getStudyMembers(studyMember.getStudy());
-        // 로그인 사용자에 (나) 붙이기
-        List<StudyMemberResponse> markedstudyMemberResponseList = mark(studyMemberResponseList, loginId);
+//        List<StudyMemberResponse> studyMemberResponseList = studyRepository.getStudyMembers(studyMember.getStudy());
+        StudyMemberResponse singleMemberResponse = studyRepository.getSingleStudyMember(studyMember.getId(), week);
+
+        List<StudyMemberResponse> singleMemberList = Collections.singletonList(singleMemberResponse);
+        List<StudyMemberResponse> markedMemberList = mark(singleMemberList, loginId);
+
         List<StudyWorkbookResponse.StudyChecklistResponse> studyChecklistList = studyRepository.getStudyChecklists(studyMember.getId(), roadmapSemester, week);
-        return studyConverter.toStudyWorkbookResponse(studyMember, markedstudyMemberResponseList, week, workbookContents, studyChecklistList);
+        return studyConverter.toStudyWorkbookResponse(studyMember, markedMemberList, week, workbookContents, studyChecklistList);
     }
 
     @Override


### PR DESCRIPTION
## 💼 Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [x] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 📚 PR Desciption

> 변경 사항 설명

- 주차별 워크북 조회 시 쿼리파라미터로 memberId 가 존재하면 해당하는 id의 멤버를 조회하고, 없으면 로그인한 멤버(본인)을 조회하게 로직을 수정함 (수정 이전에는 모든 스터디 멤버가 조회가 됨)
- attendance 반환 수정 (이전에는 현재 주차인 attendance 만 조회 가능하게끔 되어있었는데, 쿼리파라미터로 week 을 받으면 받은 주차에 해당하는 attendance 조회 가능하게끔 변경)

## 🪐 Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

-

## 🛰️ 관련 이슈

- close #140 
